### PR TITLE
Addition of Secrets Detection Workflows

### DIFF
--- a/.github/detect-secrets.yaml
+++ b/.github/detect-secrets.yaml
@@ -1,0 +1,61 @@
+name: "Secret Detection"
+on:
+  push:
+    branches: [main]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [main]
+
+jobs:
+  secret-detection:
+    name: Secret-Detection
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Upgrade tooling
+      run: |
+        python3 -m pip install --upgrade pip
+        pip install detect-secrets==1.5.0
+        pip install jq==1.8.0
+    - name: Scan
+      run: |
+        # scripts scan repository for new secrets
+        # backup list of known secrets
+        cp -pr .secrets.baseline .secrets.new
+        # find secrets in the repository
+        detect-secrets scan --baseline .secrets.new
+        # break build when new secrets discovered
+        # function compares baseline/new secrets w/o listing results -- success(0) when new secret found
+        compare_secrets() { diff <(jq -r '.results | keys[] as $key | "\($key),\(.[$key] | .[] | .hashed_secret)"' "${1}" | sort) <(jq -r '.results | keys[] as $key | "\($key),\(.[$key] | .[] | .hashed_secret)"' "${2}" | sort) | grep -q '>' ; }
+        # test baseline versus new secret files
+        if compare_secrets .secrets.baseline .secrets.new; 
+        then
+            echo "⚠️ Attention Required! ⚠️" >&2
+            echo "New secrets have been detected in your recent commit. Due to security concerns, we cannot display detailed information here and we cannot proceed until this issue is resolved." >&2
+            echo "" >&2
+            echo "Please follow the steps below on your local machine to reveal and handle the secrets:" >&2
+            echo "" >&2
+            echo "1️⃣ Run the 'detect-secrets' tool on your local machine. This tool will identify and clean up the secrets:" >&2
+            echo "" >&2
+            echo "    \$ detect-secrets scan --all-files --exclude-files '\.secrets\..*' --exclude-files '\.git.*' --exclude-files '\.pytest_cache' --exclude-files '\.venv' --exclude-files 'venv' --exclude-files 'dist' --exclude-files 'build' --exclude-files '.*\.egg-info' > .secrets.baseline" >&2
+            echo "" >&2
+            echo "2️⃣ Perform an audit on the updated .secrets.baseline to disposition any new findings:" >&2
+            echo "" >&2
+            echo "    \$ detect-secrets audit .secrets.baseline" >&2
+            echo "" >&2
+            echo "❗NOTE: The audit tool will ask the following for all newly detected \"secrets\": \"Is this a secret that should be committed to this repository?\"" >&2
+            echo "" >&2
+            echo "❗If the detected secret is benign (i.e. a public email address or dummy password) the correct answer is \"y\"." >&2
+            echo "" >&2
+            echo "3️⃣ After auditing all new findings, commit the updated .secrets.baseline and push the update to origin." >&2
+            echo "" >&2
+            echo "Your efforts to maintain the security of our codebase are greatly appreciated!" >&2
+            exit 1
+        else
+            echo "🟢 Secrets tests PASSED! 🟢" >&1
+            echo "No new secrets were detected in comparison to any baseline configurations."  >&1
+            exit 0
+        fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args:
+          - '--baseline'
+          - '.secrets.baseline'

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,181 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "\\.secrets.*",
+        "\\.venv",
+        "\\.git.*",
+        "\\.pytest_cache",
+        "venv",
+        "dist",
+        "build",
+        ".*\\.egg-info"
+      ]
+    }
+  ],
+  "results": {
+    "tests/.env.sample": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/.env.sample",
+        "hashed_secret": "8f8967d6093d0fe1de3b50e72d3d80370dcd9ba6",
+        "is_verified": false,
+        "line_number": 12,
+        "is_secret": false
+      }
+    ],
+    "tests/test_dataset_from_file.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_dataset_from_file.py",
+        "hashed_secret": "f04f86e50efcd2133f79725f29afc7307f61c52e",
+        "is_verified": false,
+        "line_number": 53,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_dataset_from_file.py",
+        "hashed_secret": "d5569f392ae2cb755b0af71f843d74e59a69217c",
+        "is_verified": false,
+        "line_number": 54,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_dataset_from_file.py",
+        "hashed_secret": "e43fb56b4ead71a83bc73fc15b2eba25839c8afb",
+        "is_verified": false,
+        "line_number": 55,
+        "is_secret": false
+      }
+    ]
+  },
+  "generated_at": "2025-04-02T16:14:07Z"
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,10 +6,10 @@ simple-http-server>=0.3.1
 bcrypt>=3.1.6
 netCDF4==1.5.3
 pdfkit==0.6.1
-jinja2>=3.1.2
+jinja2>=3.1.6
 itsdangerous>=2.1.2
 click>=8.1.7
-werkzeug>=2.3.7
+werkzeug>=3.0.6
 markupsafe>=2.1.3
 bz2file==0.98
 isodate==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ pypiserver==1.3.0
 Flask-Session
 requests>=2.23
 beautifulsoup4>=4.12.0
+pre-commit>=3.3.3


### PR DESCRIPTION
This branch incorporates use of the [detect-secrets](https://github.com/Yelp/detect-secrets) application with this repo by configuring use of tool as both a pre-commit hook, as well as a Github action that should automatically run when either a new PR is opened or there is a push to `main`.

This branch also adds the initial `.secrets.baseline` file based on an audit of the findings for the current `main` branch. All findings are benign and have been marked as "not secret".

Lastly, a few pinned versions in requirements.txt have been updated to address vulnerable versions flagged by the static analyzer in PyCharm.

The following guidance from the SLIM project was used to set this up: https://nasa-ammos.github.io/slim/docs/guides/software-lifecycle/security/secrets-detection/

