### PR TITLE
Misc fixes to About MCC/API pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+- Fixed typo and wording issue in the About MCC template
+- Fixed issue in the About API template where supported Checker versions was hardcoded
+- Standardized the footer links across all MCC web page templates
+- Moved detect-secrets.yaml Github Action into the proper .github/workflow directory
 ### Security
 - Resolved snyk vulnerability finding by upgrading setuptools to v78.1.1
 - Migrated base image for MCC from centos7 to rockylinux8

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ COPY --chmod=644 requirements.txt /tmp/
 COPY --chmod=644 requirements-checkers.txt /tmp/
 
 RUN pip3.11 install --upgrade pip \
-    && pip3.11 install -r /tmp/requirements.txt /tmp/requirements-checkers.txt mod_wsgi==4.9.4 \
+    && pip3.11 install -r /tmp/requirements.txt -r /tmp/requirements-checkers.txt mod_wsgi==4.9.4 \
     && mod_wsgi-express install-module > /etc/httpd/conf.modules.d/02-wsgi.conf
 
 # This needs to be set to allow Apache/Python to write to the temp directory

--- a/mcc/web/server.py
+++ b/mcc/web/server.py
@@ -284,6 +284,7 @@ def about_api():
     """
     return render_template(
         'about_api.html',
+        checkers={checker.ABOUT['short_name']: checker.ABOUT for checker in list(CHECKERS.values())},
         max_size=format_byte_size(app.config['MAX_CONTENT_LENGTH'],),
         homepage_url=app.config['HomepageURL']
     )

--- a/mcc/web/templates/about.html
+++ b/mcc/web/templates/about.html
@@ -190,8 +190,9 @@ DISABLE TAG -->
         </div>
         <hr />
         <ul class="list-inline text-center">
-        <li><a href="{{ homepage_url }}">Metadata Compliance Checker</a></li>
-        <li><a href="https://podaac.jpl.nasa.gov/">PODAAC</a></li>
+          <li><a href="{{ homepage_url }}"><h4>MCC Home</h4></a></li>
+          <li><a href="about_api"><h4>API</h4></a></li>
+          <li><a href="https://podaac.jpl.nasa.gov/"><h4>PODAAC</h4></a></li>
         </ul>
       </div>
     </div>

--- a/mcc/web/templates/about.html
+++ b/mcc/web/templates/about.html
@@ -129,14 +129,14 @@ DISABLE TAG -->
                   <h1>About the Metadata Compliance Checker</h1>
                   <p class="lead">The Metadata Compliance Checker (MCC) is
                     an automated tool, written in Python, that checks metadata attributes for
-                    presence and correctness, and generates human-readable reports that reference the
-                    metadata alongside the standard.</p>
+                    presence and adherence to standards, and generates human-readable reports that
+                    reference the metadata alongside the standard.</p>
                   <p class="lead">MCC currently targets the ACDD, CF, and GDS2 metadata standards for
                     both ease of implementation and practical use by engineers at the Physical
                     Oceanography Distributed Active Archive Center (PO.DAAC).</p>
                   <p class="lead">In keeping with the goal of ease-of-use, MCC is implemented both
                     as a web application and as a public <a href="about_api">API</a>.
-                    Complance reports can be returned either in HTML, PDF, or JavaScript Object Notation
+                    Compliance reports can be returned either in HTML, PDF, or JavaScript Object Notation
                     (JSON) formats.</p>
                 </div>
 

--- a/mcc/web/templates/about_api.html
+++ b/mcc/web/templates/about_api.html
@@ -152,7 +152,7 @@ DISABLE TAG -->
                   <tr>
                     <td>ACDD-version</td>
                     <td>If provided, 'ACDD' tag must also be present</td>
-                    <td><strong>1.1, 1.3</strong></td>
+                    <td><strong>{{ checkers['ACDD']['versions']|join(', ') }}</strong></td>
                   </tr>
                   <tr>
                     <td>CF</td>
@@ -162,7 +162,7 @@ DISABLE TAG -->
                   <tr>
                     <td>CF-version</td>
                     <td>If provided, 'CF' tag must also be present</td>
-                    <td><strong>1.6, 1.7</strong></td>
+                    <td><strong>{{ checkers['CF']['versions']|join(', ') }}</strong></td>
                   </tr>
                   <tr>
                     <td>GDS2</td>
@@ -172,7 +172,7 @@ DISABLE TAG -->
                   <tr>
                     <td>GDS2-parameter</td>
                     <td>If provided, 'GDS2' tag must also be present</td>
-                    <td><strong>L2P, L3, L4</strong></td>
+                    <td><strong>{{ checkers['GDS2']['options']|join(', ') }}</strong></td>
                   </tr>
                   <tr>
                     <td>file-upload</td>

--- a/mcc/web/templates/about_api.html
+++ b/mcc/web/templates/about_api.html
@@ -201,8 +201,9 @@ curl -L -F GDS2=on -F GDS2-parameter=L4 -F file-upload=@/home/user/granule.nc -F
         </div>
         <hr />
         <ul class="list-inline text-center">
-        <li><a href="{{ homepage_url }}">Metadata Compliance Checker</a></li>
-        <li><a href="https://podaac.jpl.nasa.gov/">PODAAC</a></li>
+          <li><a href="{{ homepage_url }}"><h4>MCC Home</h4></a></li>
+          <li><a href="about"><h4>About MCC</h4></a></li>
+          <li><a href="https://podaac.jpl.nasa.gov/"><h4>PODAAC</h4></a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
### Description

This branch adds some minor fixes to the About pages of the MCC webapp.

### Overview of work done

- Fixed typo and wording in the About MCC page
- Standardized the footer links at the bottom of each page
- The supported Checker versions are now determined dynamically within the About API page
- ~Fixed issue where the detect-secrets Github Action was checked into the wrong location~
  - This will be addressed in a future PR
- Added missing `-r` flag to requirements.txt installation step in Dockerfile

### Overview of verification done

Fixes to web pages were verified by inspection by running the webapp in a local dev environment.

#### Tested in SIT:

This branch has also been deployed to [SIT](https://mcc.podaac.sit.earthdatacloud.nasa.gov/) for inspection testing.

## PR checklist:

* [x] Linted
* [x] Unit tests
* [x] Addressed Snyk vulnerabilities
* [x] Updated changelog
* [x] Tested in SIT
* [x] Documentation / User-Guide Updated
