### PR TITLE
Separate Upload Limits for UI and API

### DIFF
--- a/env/sample_defines/defines.conf
+++ b/env/sample_defines/defines.conf
@@ -1,16 +1,19 @@
 # This should be the URL of the MCC homepage
-Define mcc_homepage "http://localhost:81/mcc"
+Define mcc_homepage "http://localhost:81/"
 
-# This sets the maximum allowable upload size in bytes
-Define maxfilesize "4295000000"
+# This sets the maximum allowable upload size in bytes for the Flask app
+Define api_maxfilesize "10737418240"
+
+# This sets the maximum allowable upload size in bytes for the Webpage frontend
+define ui_maxfilesize "4295000000"
 
 # This sets the internal container location of the temporary files. It's generally not necessary to change this.
 Define tempfilelocation "/tmp/mcc"
+
+# This should be set to the name of the venue MCC is deployed to
+Define venue "MCC"
 
 # Defines the location of the CF standard name table to use with the CF checker,
 # regardless of which CF version is utilized. Note this path should be relative
 # to the MCC code location within the built container.
 Define cfStandardNameTable "/var/www/html/mcc/utils/cf-standard-name-table-90.xml"
-
-# This should be set to the name of the venue MCC is deployed to
-Define venue "MCC"

--- a/env/sample_defines/defines.dev.conf
+++ b/env/sample_defines/defines.dev.conf
@@ -1,6 +1,15 @@
 # This should be the URL of the MCC homepage
 Define mcc_homepage "https://mcc.podaac.sit.earthdatacloud.nasa.gov"
 
+# This sets the maximum allowable upload size in bytes for the Flask app
+Define api_maxfilesize "4295000000"
+
+# This sets the maximum allowable upload size in bytes for the Webpage frontend
+define ui_maxfilesize "2000000000"
+
+# This sets the internal container location of the temporary files. It's generally not necessary to change this.
+Define tempfilelocation "/tmp/mcc"
+
 # This should be set to the name of the venue MCC is deployed to
 Define venue "DEV"
 

--- a/env/sample_defines/defines.ops.conf
+++ b/env/sample_defines/defines.ops.conf
@@ -1,16 +1,19 @@
 # This should be the external URL of the MCC homepage
 Define mcc_homepage "https://mcc.podaac.earthdatacloud.nasa.gov"
 
-# This sets the maximum allowable upload size in bytes
-Define maxfilesize "4295000000"
+# This sets the maximum allowable upload size in bytes for the Flask app
+Define api_maxfilesize "10737418240"
+
+# This sets the maximum allowable upload size in bytes for the Webpage frontend
+define ui_maxfilesize "4295000000"
 
 # This sets the internal container location of the temporary files. It's generally not necessary to change this.
 Define tempfilelocation "/tmp/mcc"
+
+# This should be set to the name of the venue MCC is deployed to
+Define venue "OPS"
 
 # Defines the location of the CF standard name table to use with the CF checker,
 # regardless of which CF version is utilized. Note this path should be relative
 # to the MCC code location within the built container.
 Define cfStandardNameTable "/var/www/html/mcc/utils/cf-standard-name-table-90.xml"
-
-# This should be set to the name of the venue MCC is deployed to
-Define venue "OPS"

--- a/env/sample_defines/defines.sit.conf
+++ b/env/sample_defines/defines.sit.conf
@@ -1,16 +1,19 @@
 # This should be the URL of the SIT MCC homepage
 Define mcc_homepage "https://mcc.podaac.sit.earthdatacloud.nasa.gov"
 
-# This sets the maximum allowable upload size in bytes
-Define maxfilesize "2000000000"
+# This sets the maximum allowable upload size in bytes for the Flask app
+Define api_maxfilesize "4295000000"
+
+# This sets the maximum allowable upload size in bytes for the Webpage frontend
+define ui_maxfilesize "2000000000"
 
 # This sets the internal container location of the temporary files. It's generally not necessary to change this.
 Define tempfilelocation "/tmp/mcc"
+
+# This should be set to the name of the venue MCC is deployed to
+Define venue "SIT"
 
 # Defines the location of the CF standard name table to use with the CF checker,
 # regardless of which CF version is utilized. Note this path should be relative
 # to the MCC code location within the built container.
 Define cfStandardNameTable "/var/www/html/mcc/utils/cf-standard-name-table-90.xml"
-
-# This should be set to the name of the venue MCC is deployed to
-Define venue "SIT"

--- a/env/sample_defines/defines.test.conf
+++ b/env/sample_defines/defines.test.conf
@@ -1,6 +1,15 @@
 # This should be the URL of the MCC homepage
 Define mcc_homepage "https://mcc.podaac.sit.earthdatacloud.nasa.gov"
 
+# This sets the maximum allowable upload size in bytes for the Flask app
+Define api_maxfilesize "4295000000"
+
+# This sets the maximum allowable upload size in bytes for the Webpage frontend
+define ui_maxfilesize "2000000000"
+
+# This sets the internal container location of the temporary files. It's generally not necessary to change this.
+Define tempfilelocation "/tmp/mcc"
+
 # This should be set to the name of the venue MCC is deployed to
 Define venue "TEST"
 

--- a/env/sample_defines/defines.uat.conf
+++ b/env/sample_defines/defines.uat.conf
@@ -1,16 +1,19 @@
 # This should be the URL of the UAT MCC homepage
 Define mcc_homepage "https://mcc.podaac.uat.earthdatacloud.nasa.gov"
 
-# This sets the maximum allowable upload size in bytes
-Define maxfilesize "2000000000"
+# This sets the maximum allowable upload size in bytes for the Flask app
+Define api_maxfilesize "4295000000"
+
+# This sets the maximum allowable upload size in bytes for the Webpage frontend
+define ui_maxfilesize "2000000000"
 
 # This sets the internal container location of the temporary files. It's generally not necessary to change this.
 Define tempfilelocation "/tmp/mcc"
+
+# This should be set to the name of the venue MCC is deployed to
+Define venue "UAT"
 
 # Defines the location of the CF standard name table to use with the CF checker,
 # regardless of which CF version is utilized. Note this path should be relative
 # to the MCC code location within the built container.
 Define cfStandardNameTable "/var/www/html/mcc/utils/cf-standard-name-table-90.xml"
-
-# This should be set to the name of the venue MCC is deployed to
-Define venue "UAT"

--- a/mcc/checker.wsgi
+++ b/mcc/checker.wsgi
@@ -11,7 +11,8 @@ sys.path.append(os.path.dirname(__file__))
 
 
 def application(environ, start_response):
-    os.environ['MaxFileSize'] = environ.get('MaxFileSize', '4295000000')
+    os.environ['ApiMaxFileSize'] = environ.get('ApiMaxFileSize', '10737418240')
+    os.environ['UiMaxFileSize'] = environ.get('UiMaxFileSize', '4295000000')
     os.environ['HomepageURL'] = environ.get('HomepageURL', '"https://mcc.podaac.earthdatacloud.nasa.gov"')
     os.environ['TempFileLocation'] = environ.get('TempFileLocation', tempfile.gettempdir())
     os.environ['Venue'] = environ.get('Venue', 'OPS')

--- a/mcc/web/server.py
+++ b/mcc/web/server.py
@@ -30,8 +30,11 @@ app.jinja_env.lstrip_blocks = True
 # The JSON encoder in use when we call flask.jsonify()
 app.json_encoder = CustomJSONEncoder
 
-# Maximum allowed file size. Typically defaults to 2-4GB.
-app.config['MAX_CONTENT_LENGTH'] = int(environ['MaxFileSize'])
+# Maximum allowed file size when submitting directly to service via API.
+app.config['MAX_CONTENT_LENGTH'] = int(environ['ApiMaxFileSize'])
+
+# Maximum allowed file size when submitting via the Web frontend.
+app.config['UiMaxFileSize'] = int(environ['UiMaxFileSize'])
 
 # URL to use for MCC homepage.
 app.config['HomepageURL'] = environ['HomepageURL']
@@ -298,8 +301,11 @@ def index():
     return render_template(
         'index.html',
         checkers=[checker.ABOUT for checker in list(CHECKERS.values())],
-        max_file_size=format_byte_size(app.config['MAX_CONTENT_LENGTH']),
-        max_file_size_bytes=app.config['MAX_CONTENT_LENGTH'],
+        max_ui_file_size=format_byte_size(app.config['UiMaxFileSize']),
+        max_ui_file_size_bytes=app.config['UiMaxFileSize'],
+        max_api_file_size=format_byte_size(app.config['MAX_CONTENT_LENGTH']),
+        max_api_file_size_bytes=app.config['MAX_CONTENT_LENGTH'],
+        homepage_url=app.config['HomepageURL'],
         mcc_version=str(mcc_version),
         venue=(app.config['Venue'])
     )

--- a/mcc/web/server.py
+++ b/mcc/web/server.py
@@ -63,23 +63,14 @@ with open('/var/www/html/mcc/web/VERSION', 'r') as f:
 # Apache will instead, meaning the page will not be styled or templated.
 @app.errorhandler(413)
 def req_entity_too_large(err):
-    if request.form.get('response') in ('html', 'pdf'):
-        ret = render_template(
-            'error.html',
-            error='File upload too large',
-            text="",
-            description=f"The maximum upload size is {format_byte_size(app.config['MAX_CONTENT_LENGTH'])}.",
-            homepage_url=app.config['HomepageURL']
-        )
-        return ret, 413
-    # Default to JSON-format response
-    else:
-        ret = {
-            'error': 'File upload too large',
-            'text': '',
-            'description': f"The maximum upload size is {format_byte_size(app.config['MAX_CONTENT_LENGTH'])}."
-        }
-        return jsonify(ret), 413
+    # We should only ever reach this handler when a granule is submitted directly
+    # to the API, so default to a JSON-format response
+    ret = {
+        'error': 'File upload too large',
+        'text': '',
+        'description': f"The maximum upload size is {format_byte_size(app.config['MAX_CONTENT_LENGTH'])}."
+    }
+    return jsonify(ret), 413
 
 
 @app.errorhandler(500)

--- a/mcc/web/static/css/template.css
+++ b/mcc/web/static/css/template.css
@@ -700,7 +700,7 @@ span{
 	font-family: Arial, sans-serif;
 	font-weight: 300;
 	margin: 2px;
-	width: 680px;
+	width: 800px;
 }
 
 .local-panel {

--- a/mcc/web/templates/index.html
+++ b/mcc/web/templates/index.html
@@ -139,7 +139,7 @@ DISABLE TAG -->
                 <form id="uploadForm" enctype="multipart/form-data">
                   <div class="form-group">
                     <label for="fileInput">
-                      <h4>Select a netCDF file: <small>maximum size {{ max_file_size }}<br>
+                      <h4>Select a netCDF file: <small>maximum size {{ max_ui_file_size }}<br>
                         MCC supports valid netCDF files including those that are compressed with gzip or bzip.<br>
                         Acceptable file extensions are: .gz, .bz2, .nc, .h5, .nc4 and .hdf.</small></h4>
                     </label>
@@ -154,12 +154,17 @@ DISABLE TAG -->
 
                     <div id="warningDiv" class="warning-msg" style="display: none;">
                       <i class="fa fa-warning"></i>
-                      Selected file is Large. Recommendation: File Upload and processing will perform better with <a href="https://mcc.podaac.earthdatacloud.nasa.gov/mcc/about_api">MCC API</a>
+                      Selected file is Large. Recommendation: File Upload and processing will perform better using the <a href="{{ homepage_url }}/about_api">MCC API</a>.
                     </div>
 
-                    <div id="errorDiv" class="warning-msg" style="display: none;">
+                    <div id="errorDivUi" class="warning-msg" style="display: none;">
                       <i class="fa fa-warning" style="color:red"></i>
-                      Selected file exceeds the upload limit of {{ max_file_size }}.
+                      Selected file exceeds this page's upload limit of {{ max_ui_file_size }}. Please submit via the <a href="{{ homepage_url }}/about_api">MCC API</a>, which has a limit of {{ max_api_file_size }}.
+                    </div>
+
+                    <div id="errorDivApi" class="warning-msg" style="display: none;">
+                      <i class="fa fa-warning" style="color:red"></i>
+                      Selected file exceeds this page's upload limit of {{ max_ui_file_size }} and the API's upload limit of {{ max_api_file_size }}. Unable to process.
                     </div>
 
                     <div id="progressDiv" class="progress progress-striped active" style="display: none;">
@@ -376,7 +381,8 @@ function postFile() {
       // Clear any existing progress bar and warning to prepare for new selected file
       document.getElementById("progressDiv").style.display = 'none';
       document.getElementById("warningDiv").style.display = 'none';
-      document.getElementById("errorDiv").style.display = 'none';
+      document.getElementById("errorDivUi").style.display = 'none';
+      document.getElementById("errorDivApi").style.display = 'none';
 
       // Reenable the upload button
       document.getElementById("uploadButton").disabled = false;
@@ -390,8 +396,12 @@ function postFile() {
 
         // If we've been given a file that exceeds size limit, display error box and disable
         // the submit button
-        if (file.size > {{ max_file_size_bytes }}){
-          document.getElementById("errorDiv").style.display = 'block';
+        if (file.size > {{ max_api_file_size_bytes }}){
+          document.getElementById("errorDivApi").style.display = 'block';
+          document.getElementById("uploadButton").disabled = true;
+        }
+        else if (file.size > {{ max_ui_file_size_bytes }}){
+          document.getElementById("errorDivUi").style.display = 'block';
           document.getElementById("uploadButton").disabled = true;
         }
         // If we've been given a large file, display the warning box

--- a/mcc_wsgi.conf
+++ b/mcc_wsgi.conf
@@ -37,10 +37,20 @@ Deny from all
 
 TimeOut 600
 
-#Set limit on file upload size (in bytes). This also limits to the size of any uncompressed gzip and bzip files.
-SetEnv MaxFileSize ${maxfilesize}
+# Set limit on file upload size (in bytes) when submitting directly to the REST API.
+# This also limits the size of any uncompressed gzip and bzip files.
+SetEnv ApiMaxFileSize ${api_maxfilesize}
+
+# Set limit on file upload size (in bytes) when submitting via the Web frontend.
+SetEnv UiMaxFileSize ${ui_maxfilesize}
+
+# Set the URL to redirect to the MCC main page
 SetEnv HomepageURL ${mcc_homepage}
+
+# Set the location to write temporary files to
 SetEnv TempFileLocation ${tempfilelocation}
+
+# Assign the venue displayed on the MCC homepage
 SetEnv Venue ${venue}
 
 # Set the envvar the compliance-checker package looks for to override the default standard names table


### PR DESCRIPTION
Ticket: [PODAAC-6901](https://jira.jpl.nasa.gov/browse/PODAAC-6901)

### Description

This branch configures separate upload size limits for use with the Webapp UI and the MCC Flask server. This should allow greater flexibility for users to submit granules that are too large for the typical UI limit (~5GB), but still a reasonable size for direct submission via the REST API (<~10GB).

### Overview of work done

There are now 2 size limit values configured in each of the `defines.conf` used for each venue. The API limit defines the size limit provided to Flask to have it reject any upload attempts that exceed the limit. The UI limit defines the size limit the Webapp looks for when a user selects a granule for upload.

The UI will now notify users where a granule is too large for the Webapp, but acceptable for API submission:
<img width="916" alt="Screenshot 2025-05-19 at 12 17 47 PM" src="https://github.com/user-attachments/assets/40a6de90-23bb-4a74-be8c-83eb993f8aa6" />

A separate message is displayed if a granule is too large for both the UI and the API:
<img width="884" alt="Screenshot 2025-05-19 at 12 17 07 PM" src="https://github.com/user-attachments/assets/f78a9714-da01-4daa-89f5-148f16db0989" />


### Overview of verification done

In addition to visual inspection of the changes to the UI, verification of the limit on API submission has also been verified in a dev deployment via curl:

 
<img width="1542" alt="Screenshot 2025-05-19 at 12 20 56 PM" src="https://github.com/user-attachments/assets/455d5815-8dc2-4c9b-aaef-d9f7b68ee723" />


#### Tested in SIT:

N/A

## PR checklist:

* [ ] Linted
* [ ] Unit tests
* [ ] Addressed Snyk vulnerabilities
* [ ] Updated changelog
* [ ] Tested in SIT
* [ ] Documentation / User-Guide Updated
