### PR TITLE
Increase LimitRequestBody to 10 GB for handling larger file uploads

### DIFF
--- a/mcc_wsgi.conf
+++ b/mcc_wsgi.conf
@@ -29,6 +29,7 @@ WSGIScriptAlias / /var/www/html/mcc/checker.wsgi
 <Directory /var/www/html/mcc>
 Order allow,deny
 Allow from all
+LimitRequestBody 10737418240
 </Directory>
 
 <Directory /usr/share/httpd/icons>


### PR DESCRIPTION
### Description

Increase the Apache `LimitRequestBody` size to support larger file uploads required by the MCC application when validating NetCDF files.

### Overview of work done

- Added the `LimitRequestBody` directive in the Apache configuration  
- Set the limit to **10 GB** (`10737418240` bytes)  
- Enables MCC to accept and process large files without request size rejections

### Overview of verification done

- Confirmed MCC can accept larger file uploads without hitting request size limits

#### Tested in SIT:
- Yes, using curl, because the API is recommended for larger file uplaods.

File size used: 2.28 GB


**Before fix (failing with error):**

<img width="1490" height="152" alt="Screenshot 2026-01-16 at 5 03 01 PM" src="https://github.com/user-attachments/assets/db39e951-5ad2-4c5c-9b64-1cd72139bf02" />


**After fix (JSOn report generated successfully):****
[
<img width="1490" height="86" alt="Screenshot 2026-01-16 at 6 20 09 PM" src="https://github.com/user-attachments/assets/20276572-bf1d-4795-ad4a-64c4b780b819" />
](url)




#### Related issues:
MCC upload/curl
https://jira.jpl.nasa.gov/browse/PODAAC-7294


## PR checklist:

* [ ] Linted
* [ ] Unit tests
* [ ] Addressed Snyk vulnerabilities
* [ ] Updated changelog
* [ ] Tested in SIT
* [ ] Documentation / User-Guide Updated
