### PR TITLE
Podaac 7294 support large file uploads

### DIFF
--- a/mcc/web/templates/about_api.html
+++ b/mcc/web/templates/about_api.html
@@ -191,24 +191,36 @@ DISABLE TAG -->
                   <p>
                     <em>Note that you need to append an '@' to the beginning of the filename in the CURL request when using the file-upload option.</em>
                   </p>
+                  <p>
+                    <em>When requesting HTML or PDF output, be sure to specify an output file with <code>-o</code>. Otherwise the response body will be printed to the terminal instead of being saved to a file. You may also use <code>-o</code> for JSON responses if you want to save the output.</em>
+                  </p>
+
                   <h4>Basic Examples</h4>
-                  <pre>curl -L -F ACDD=on -F ACDD-version=1.3 -F file-upload=@/home/user/granule.nc -F response=json {{ homepage_url }}/check
-curl -L -F CF=on -F CF-version=1.7 -F file-upload=@/home/user/granule.nc -F response=html {{ homepage_url }}/check
-curl -L -F GDS2=on -F GDS2-parameter=L4 -F file-upload=@/home/user/granule.nc -F response=pdf {{ homepage_url }}/check</pre>
-                  
+                  <pre>curl -L -F ACDD=on -F ACDD-version=1.3 -F file-upload=@/home/user/granule.nc -F response=json -o result.json {{ homepage_url }}/check
+curl -L -F CF=on -F CF-version=1.7 -F file-upload=@/home/user/granule.nc -F response=html -o result.html {{ homepage_url }}/check
+curl -L -F GDS2=on -F GDS2-parameter=L4 -F file-upload=@/home/user/granule.nc -F response=pdf -o result.pdf {{ homepage_url }}/check</pre>
+
                   <h4>With Progress Reporting and Extended Timeouts</h4>
                   <p>
-                    <em>For large files, you may want to show progress and set longer timeouts:</em>
+                    <em>For large files, you may want to show progress, set longer timeouts, and save the response to an output file:</em>
                   </p>
                   <pre>curl -L --progress-bar --connect-timeout 300 --max-time 3600 --keepalive-time 3600 \
-    -F ACDD=on -F ACDD-version=1.3 -F file-upload=@/home/user/granule.nc -F response=json {{ homepage_url }}/check</pre>
-                  
+    -F ACDD=on -F ACDD-version=1.3 -F file-upload=@/home/user/granule.nc -F response=json \
+    -o result.json {{ homepage_url }}/check</pre>
+
                   <h4>With Detailed Progress</h4>
                   <pre>curl -L -v --progress-meter --connect-timeout 300 --max-time 3600 --keepalive-time 3600 \
-    -F CF=on -F CF-version=1.7 -F file-upload=@/home/user/granule.nc -F response=html {{ homepage_url }}/check</pre>
-                  
+    -F CF=on -F CF-version=1.7 -F file-upload=@/home/user/granule.nc -F response=html \
+    -o result.html {{ homepage_url }}/check</pre>
+
+                  <h4>Saving PDF Output</h4>
+                  <pre>curl -L --progress-bar --connect-timeout 300 --max-time 3600 --keepalive-time 3600 \
+    -F GDS2=on -F GDS2-parameter=L4 -F file-upload=@/home/user/granule.nc -F response=pdf \
+    -o result.pdf {{ homepage_url }}/check</pre>
+
                   <h4>Options Explained</h4>
                   <ul>
+                    <li><code>-o &lt;filename&gt;</code>: Save the response body to the specified file</li>
                     <li><code>--progress-bar</code>: Display a simple progress bar</li>
                     <li><code>--progress-meter</code>: Display detailed progress information</li>
                     <li><code>-v</code>: Verbose output showing request and response headers</li>

--- a/terraform/fargate.tf
+++ b/terraform/fargate.tf
@@ -85,7 +85,7 @@ resource "aws_ecs_task_definition" "fargate_task" {
     },
     {
       name  = "${local.ec2_resources_name}-proxy"
-      image = "ghcr.io/podaac/ngap-dit-proxy"
+      image = "ghcr.io/podaac/ngap-dit-proxy:1.0.0-large-upload-test"
       essential = true
       environment = [
         {

--- a/terraform/fargate.tf
+++ b/terraform/fargate.tf
@@ -85,7 +85,7 @@ resource "aws_ecs_task_definition" "fargate_task" {
     },
     {
       name  = "${local.ec2_resources_name}-proxy"
-      image = "ghcr.io/podaac/ngap-dit-proxy:1.0.0-large-upload-test"
+      image = "ghcr.io/podaac/ngap-dit-proxy:1.1.0"
       essential = true
       environment = [
         {


### PR DESCRIPTION
### Description

Update the MCC deployment to use the newly released proxy image `ghcr.io/podaac/ngap-dit-proxy:1.1.0`, which was capable of uploading files as large as 4 GB+. Update `about_api.html` to clarify that users should specify an output file name when saving JSON, HTML, or PDF responses from curl.

### Overview of work done

- updated the proxy image reference to `ghcr.io/podaac/ngap-dit-proxy:1.1.0` which was capable of uploading files as large as 4 GB+
- updated `about_api.html` with clearer curl examples showing use of `-o` to save response output to a file
- added more detail to the API documentation for JSON, HTML, and PDF output examples
- clarified progress and timeout examples for large file uploads

### Overview of verification done

- verified the updated `ngap-dit-proxy` image worked correctly for large upload handling with 2 GB+ and 4 GB+ files
- verified the released `1.1.0` image is the intended production image to replace the temporary SIT test tag
- reviewed the updated `about_api.html` examples to ensure they clearly show output file usage for saved results

#### Tested in SIT:

- previously validated large upload behavior in SIT using this PODAAC-7294-support-large-file-uploads branch
- confirmed  that SIT environment now use the official released proxy image instead of the temporary test image

The following screenshot shows successful `curl` based uploads of 700MB+ and 4GB+ size files.
<img width="1491" height="194" alt="Screenshot 2026-03-19 at 2 09 13 PM" src="https://github.com/user-attachments/assets/9bc332b5-dea1-4404-a56d-920d8aa0f114" />


#### Related Issues
https://jira.jpl.nasa.gov/browse/PODAAC-7294

## PR checklist:

* [x] Linted
* [x] Intergation tests
* [ ] Addressed Snyk vulnerabilities
* [ ] Updated changelog
* [x] Tested in SIT
* [x] Documentation / User-Guide Updated
